### PR TITLE
optimise workflow

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -63,7 +63,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "8.2"
+          - "8.4"
         operating-system:
           - "ubuntu-latest"
 
@@ -99,8 +99,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "8.2"
-          - "8.3"
+          - "8.4"
         operating-system:
           - "ubuntu-latest"
 
@@ -134,7 +133,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "8.2"
+          - "8.4"
         operating-system:
           - "ubuntu-latest"
 


### PR DESCRIPTION
- to save resources, only run phpunit on all php versions, php 8.4 for the rest