### PR TITLE
fixing pugx badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ this might be especially useful when you switched to using the [phrase translati
 
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FwickedOne%2Fphrase-tag-bundle%2Fmaster)](https://dashboard.stryker-mutator.io/reports/github.com/wickedOne/phrase-tag-bundle/master)
 [![codecov](https://codecov.io/gh/wickedOne/phrase-tag-bundle/branch/master/graph/badge.svg?token=UHKAVGURP7)](https://codecov.io/gh/wickedOne/phrase-tag-bundle)
-[![Latest Stable Version](http://poser.pugx.org/wickedone/phrase-tag-bundle/v)](https://packagist.org/packages/wickedone/phrase-tag-bundle)
-[![Total Downloads](http://poser.pugx.org/wickedone/phrase-tag-bundle/downloads)](https://packagist.org/packages/wickedone/phrase-tag-bundle)
-[![License](http://poser.pugx.org/wickedone/phrase-tag-bundle/license)](https://packagist.org/packages/wickedone/phrase-tag-bundle)
-[![PHP Version Require](http://poser.pugx.org/wickedone/phrase-tag-bundle/require/php)](https://packagist.org/packages/wickedone/phrase-tag-bundle)
+[![Latest Stable Version](https://poser.pugx.org/wickedone/phrase-tag-bundle/v)](https://packagist.org/packages/wickedone/phrase-tag-bundle)
+[![Total Downloads](https://poser.pugx.org/wickedone/phrase-tag-bundle/downloads)](https://packagist.org/packages/wickedone/phrase-tag-bundle)
+[![License](https://poser.pugx.org/wickedone/phrase-tag-bundle/license)](https://packagist.org/packages/wickedone/phrase-tag-bundle)
+[![PHP Version Require](https://poser.pugx.org/wickedone/phrase-tag-bundle/require/php)](https://packagist.org/packages/wickedone/phrase-tag-bundle)
 
 ## Installation
 


### PR DESCRIPTION
301 redirect to https prevents camo from properly proxying images