### PR TITLE
optional query

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -27,7 +27,6 @@ return (new PhpCsFixer\Config())
         'strict_comparison' => true,
         'strict_param' => true,
         'fopen_flags' => array('b_mode' => true),
-        'native_function_invocation' => false,
     ))
     ->setFinder(
         (new PhpCsFixer\Finder())

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ this command helps you to batch tag keys in phrase by querying for existing tags
 you can search for multiple tags at once and a broad search on key name using the `*` wildcard.
 keep in mind the query is an AND query, meaning the keys have to match all criteria.
 
+> [!TIP]
+> if you want to match **all** keys, simply omit the query-key (`-k`) and query-tag (`-t`) options
+
 **example**:
 
 ```bash
@@ -99,6 +102,9 @@ when you add the `--dry-run` option to the command, it will list the first 100 m
 this command helps you to batch remove tags from keys in phrase by querying for existing tags and / or key name.
 you can search for multiple tags at once and a broad search on key name using the `*` wildcard.
 keep in mind the query is an AND query, meaning the keys have to match all criteria.
+
+> [!TIP]
+> if you want to match **all** keys, simply omit the query-key (`-k`) and query-tag (`-t`) options
 
 **example**:
 

--- a/src/Command/AbstractPhraseKeyCommand.php
+++ b/src/Command/AbstractPhraseKeyCommand.php
@@ -48,12 +48,6 @@ abstract class AbstractPhraseKeyCommand extends Command
         /** @var string[] $tags */
         $tags = $input->getOption('query-tag');
 
-        if (null === $key && [] === $tags) {
-            $output->writeln('<error>no query parameters provided</error>');
-
-            return Command::FAILURE;
-        }
-
         if (true === $input->getOption('dry-run')) {
             return $this->list($output, $key, $tags);
         }

--- a/src/Command/AbstractPhraseKeyCommand.php
+++ b/src/Command/AbstractPhraseKeyCommand.php
@@ -71,7 +71,7 @@ abstract class AbstractPhraseKeyCommand extends Command
         try {
             $result = $this->tagService->list($key, $tags);
         } catch (ProviderException $e) {
-            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+            $output->writeln(\sprintf('<error>%s</error>', $e->getMessage()));
 
             return Command::FAILURE;
         }
@@ -85,7 +85,7 @@ abstract class AbstractPhraseKeyCommand extends Command
         $output->writeln('<info>your query would match the following keys (sample):</info>');
 
         foreach ($result as $item) {
-            $output->writeln(sprintf('<comment>></comment> <info>%s</info>', $item));
+            $output->writeln(\sprintf('<comment>></comment> <info>%s</info>', $item));
         }
 
         return Command::SUCCESS;

--- a/src/Command/PhraseKeyTagCommand.php
+++ b/src/Command/PhraseKeyTagCommand.php
@@ -46,12 +46,12 @@ class PhraseKeyTagCommand extends AbstractPhraseKeyCommand
         try {
             $keys = $this->tagService->tag($queryKey, $queryTag, $tag);
         } catch (ProviderException $e) {
-            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+            $output->writeln(\sprintf('<error>%s</error>', $e->getMessage()));
 
             return Command::FAILURE;
         }
 
-        $output->writeln(sprintf('<info>successfully tagged %d keys with "%s"</info>', $keys, implode(', ', $tag)));
+        $output->writeln(\sprintf('<info>successfully tagged %d keys with "%s"</info>', $keys, implode(', ', $tag)));
 
         return Command::SUCCESS;
     }

--- a/src/Command/PhraseKeyUntagCommand.php
+++ b/src/Command/PhraseKeyUntagCommand.php
@@ -46,12 +46,12 @@ class PhraseKeyUntagCommand extends AbstractPhraseKeyCommand
         try {
             $keys = $this->tagService->untag($queryKey, $queryTag, $tag);
         } catch (ProviderException $e) {
-            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+            $output->writeln(\sprintf('<error>%s</error>', $e->getMessage()));
 
             return Command::FAILURE;
         }
 
-        $output->writeln(sprintf('<info>successfully untagged %d keys with "%s"</info>', $keys, implode(', ', $tag)));
+        $output->writeln(\sprintf('<info>successfully untagged %d keys with "%s"</info>', $keys, implode(', ', $tag)));
 
         return Command::SUCCESS;
     }

--- a/src/Service/PhraseTagService.php
+++ b/src/Service/PhraseTagService.php
@@ -34,12 +34,14 @@ class PhraseTagService
      */
     public function list(?string $key, array $tags): array
     {
+        $query = array_filter([
+            'page' => '1',
+            'per_page' => '100',
+            'q' => $this->createQuery($key, $tags),
+        ], static fn (string $value): bool => '' !== $value);
+
         $response = $this->httpClient->request('GET', 'keys', [
-            'query' => [
-                'page' => '1',
-                'per_page' => '100',
-                'q' => $this->createQuery($key, $tags),
-            ],
+            'query' => $query,
         ]);
 
         if (200 !== $statusCode = $response->getStatusCode()) {
@@ -59,15 +61,18 @@ class PhraseTagService
     public function tag(?string $key, array $tags, array $addTags): int
     {
         $query = $this->createQuery($key, $tags);
+
+        $body = array_filter([
+            'q' => $query,
+            'tags' => implode(',', $addTags),
+        ], static fn (string $value): bool => '' !== $value);
+
         $response = $this->httpClient->request('PATCH', 'keys/tag', [
             'query' => [
                 'page' => '1',
                 'per_page' => '100',
             ],
-            'body' => [
-                'q' => $query,
-                'tags' => implode(',', $addTags),
-            ],
+            'body' => $body,
         ]);
 
         if (200 !== $statusCode = $response->getStatusCode()) {
@@ -90,15 +95,18 @@ class PhraseTagService
     public function untag(?string $key, array $tags, array $removeTags): int
     {
         $query = $this->createQuery($key, $tags);
+
+        $body = array_filter([
+            'q' => $query,
+            'tags' => implode(',', $removeTags),
+        ], static fn (string $value): bool => '' !== $value);
+
         $response = $this->httpClient->request('PATCH', 'keys/untag', [
             'query' => [
                 'page' => '1',
                 'per_page' => '100',
             ],
-            'body' => [
-                'q' => $query,
-                'tags' => implode(',', $removeTags),
-            ],
+            'body' => $body,
         ]);
 
         if (200 !== $statusCode = $response->getStatusCode()) {

--- a/src/Service/PhraseTagService.php
+++ b/src/Service/PhraseTagService.php
@@ -45,7 +45,7 @@ class PhraseTagService
         ]);
 
         if (200 !== $statusCode = $response->getStatusCode()) {
-            throw new ProviderException(sprintf('phrase replied with an error (%d): "%s"', $statusCode, $response->getContent(false)), $response);
+            throw new ProviderException(\sprintf('phrase replied with an error (%d): "%s"', $statusCode, $response->getContent(false)), $response);
         }
 
         /** @var array{name: string} $arr */
@@ -76,14 +76,14 @@ class PhraseTagService
         ]);
 
         if (200 !== $statusCode = $response->getStatusCode()) {
-            throw new ProviderException(sprintf('phrase replied with an error (%d): "%s"', $statusCode, $response->getContent(false)), $response);
+            throw new ProviderException(\sprintf('phrase replied with an error (%d): "%s"', $statusCode, $response->getContent(false)), $response);
         }
 
         /** @var array{records_affected: string} $arr */
         $arr = $response->toArray();
         $records = $arr['records_affected'];
 
-        $this->logger->info(sprintf('tagged %d keys matching "%s" with tag(s) "%s"', $records, $query, implode(', ', $addTags)));
+        $this->logger->info(\sprintf('tagged %d keys matching "%s" with tag(s) "%s"', $records, $query, implode(', ', $addTags)));
 
         return (int) $records;
     }
@@ -110,14 +110,14 @@ class PhraseTagService
         ]);
 
         if (200 !== $statusCode = $response->getStatusCode()) {
-            throw new ProviderException(sprintf('phrase replied with an error (%d): "%s"', $statusCode, $response->getContent(false)), $response);
+            throw new ProviderException(\sprintf('phrase replied with an error (%d): "%s"', $statusCode, $response->getContent(false)), $response);
         }
 
         /** @var array{records_affected: string} $arr */
         $arr = $response->toArray();
         $records = $arr['records_affected'];
 
-        $this->logger->info(sprintf('untagged %d keys matching "%s" with tag(s) "%s"', $records, $query, implode(', ', $removeTags)));
+        $this->logger->info(\sprintf('untagged %d keys matching "%s" with tag(s) "%s"', $records, $query, implode(', ', $removeTags)));
 
         return (int) $records;
     }

--- a/tests/Unit/Command/AbstractPhraseKeyCommandTest.php
+++ b/tests/Unit/Command/AbstractPhraseKeyCommandTest.php
@@ -76,18 +76,6 @@ class AbstractPhraseKeyCommandTest extends TestCase
         $this->assertSame('something went wrong', trim($commandTester->getDisplay()));
     }
 
-    public function testInputFailure(): void
-    {
-        $commandTester = $this->createCommandTester();
-        $commandTester->execute([
-            'command' => PhraseKeyTagCommand::getDefaultName(),
-            '-t' => [],
-        ]);
-
-        $this->assertSame(Command::FAILURE, $commandTester->getStatusCode());
-        $this->assertSame('no query parameters provided', trim($commandTester->getDisplay()));
-    }
-
     public function testInputFailureNoDryRun(): void
     {
         $commandTester = $this->createCommandTester();

--- a/tests/Unit/Service/PhraseTagServiceTest.php
+++ b/tests/Unit/Service/PhraseTagServiceTest.php
@@ -103,7 +103,7 @@ class PhraseTagServiceTest extends TestCase
         $this->getLogger()
             ->expects(self::once())
             ->method('info')
-                ->with(sprintf('tagged 10 keys matching "%s" with tag(s) "%s"', $this->query($key, $tags), implode(', ', $newTags)));
+                ->with(\sprintf('tagged 10 keys matching "%s" with tag(s) "%s"', $this->query($key, $tags), implode(', ', $newTags)));
 
         $responses = [
             'tag keys' => function (string $method, string $url, array $options = []) use ($key, $tags, $newTags): ResponseInterface {
@@ -158,7 +158,7 @@ class PhraseTagServiceTest extends TestCase
         $this->getLogger()
             ->expects(self::once())
             ->method('info')
-            ->with(sprintf('untagged 10 keys matching "%s" with tag(s) "%s"', $this->query($key, $tags), implode(', ', $newTags)));
+            ->with(\sprintf('untagged 10 keys matching "%s" with tag(s) "%s"', $this->query($key, $tags), implode(', ', $newTags)));
 
         $responses = [
             'untag keys' => function (string $method, string $url, array $options = []) use ($key, $tags, $newTags): ResponseInterface {

--- a/tests/Unit/Service/PhraseTagServiceTest.php
+++ b/tests/Unit/Service/PhraseTagServiceTest.php
@@ -44,11 +44,11 @@ class PhraseTagServiceTest extends TestCase
     {
         $responses = [
             'list keys' => function (string $method, string $url) use ($key, $tags, $responseContent): ResponseInterface {
-                $parts = [
+                $parts = array_filter([
                     'page' => '1',
                     'per_page' => '100',
                     'q' => $this->query($key, $tags),
-                ];
+                ], static fn (string $value): bool => '' !== $value);
 
                 $queryString = $this->mergeQueryString(null, $parts, true);
                 $this->assertSame('GET', $method);
@@ -107,7 +107,7 @@ class PhraseTagServiceTest extends TestCase
 
         $responses = [
             'tag keys' => function (string $method, string $url, array $options = []) use ($key, $tags, $newTags): ResponseInterface {
-                $body = ['q' => $this->query($key, $tags), 'tags' => implode(',', $newTags)];
+                $body = array_filter(['q' => $this->query($key, $tags), 'tags' => implode(',', $newTags)], static fn (string $value): bool => '' !== $value);
                 $this->assertSame('PATCH', $method);
                 $this->assertSame('https://api.phrase.com/api/v2/projects/1/keys/tag?page=1&per_page=100', $url);
                 $this->assertSame(http_build_query($body), $options['body']);
@@ -162,7 +162,7 @@ class PhraseTagServiceTest extends TestCase
 
         $responses = [
             'untag keys' => function (string $method, string $url, array $options = []) use ($key, $tags, $newTags): ResponseInterface {
-                $body = ['q' => $this->query($key, $tags), 'tags' => implode(',', $newTags)];
+                $body = array_filter(['q' => $this->query($key, $tags), 'tags' => implode(',', $newTags)], static fn (string $value): bool => '' !== $value);
                 $this->assertSame('PATCH', $method);
                 $this->assertSame('https://api.phrase.com/api/v2/projects/1/keys/untag?page=1&per_page=100', $url);
                 $this->assertSame(http_build_query($body), $options['body']);
@@ -266,6 +266,12 @@ JSON;
         yield 'key and tags' => [
             'key' => 'translation.*',
             'tags' => ['tag-one', 'tag-two'],
+            'responseContent' => $content,
+        ];
+
+        yield 'no key no tags' => [
+            'key' => null,
+            'tags' => [],
             'responseContent' => $content,
         ];
     }


### PR DESCRIPTION
closes #57 

make both `--query-key` (`-k`) and `--query-tag` (`-t`) optional to be able to match all keys in your project